### PR TITLE
feat: add simulated GPS (NavSat) sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ CHAMP (Coupled Hybrid Automata for Mobile Platforms) is an open-source developme
   - ✅ 3D LiDAR (4D Lidar L1) (need some imporvments)
   - ✅ Mono Camera
   - ❌ Depth Camera
-  - ❌ GPS
+  - ✅ GPS (NavSat — simulates standard u-blox, ~0.5 m horizontal accuracy)
 - ✅ Point cloud visualization in RVIZ
 - ✅ Multiple sensor configurations available
 - ❌ Full SLAM functionality (Coming soon)
@@ -136,6 +136,40 @@ Control the robot using keyboard:
 ```bash
 ros2 run teleop_twist_keyboard teleop_twist_keyboard
 ```
+
+### GPS Simulation
+
+The robot includes a simulated GPS (NavSat) sensor mounted on top of the trunk, publishing at 10 Hz on `/gps/fix` as `sensor_msgs/msg/NavSatFix`.
+
+The sensor models standard u-blox-level accuracy:
+
+| Axis | Noise (std dev) | Equivalent variance |
+|------|----------------|---------------------|
+| Horizontal (lat/lon) | 0.5 m | 0.25 m² |
+| Vertical (altitude) | 0.8 m | 0.64 m² |
+
+**Verify it is working:**
+
+```bash
+ros2 topic echo /gps/fix
+```
+
+**Setting the geographic origin:**
+
+The world's GPS origin is defined in `unitree_go2_description/worlds/default.sdf` under `<spherical_coordinates>`. Edit `latitude_deg`, `longitude_deg`, and `elevation` to match your actual test site before running navigation experiments:
+
+```xml
+<spherical_coordinates>
+  <surface_model>EARTH_WGS84</surface_model>
+  <world_frame_orientation>ENU</world_frame_orientation>
+  <latitude_deg>YOUR_LAT</latitude_deg>
+  <longitude_deg>YOUR_LON</longitude_deg>
+  <elevation>YOUR_ALT_METERS</elevation>
+  <heading_deg>0</heading_deg>
+</spherical_coordinates>
+```
+
+> **Note:** The `position_covariance` field in the bridged message will be all-zeros (`COVARIANCE_TYPE_UNKNOWN`) because the Gazebo→ROS bridge does not carry covariance. When integrating with `robot_localization`, set the covariance override in your EKF config or add a relay node that stamps diagonal covariance values matching the noise above.
 
 ## Tuning Gait Parameters
 

--- a/unitree_go2_description/urdf/unitree_go2_gazebo.xacro
+++ b/unitree_go2_description/urdf/unitree_go2_gazebo.xacro
@@ -99,6 +99,46 @@
             </sensor>
         </gazebo>
 
+        <!-- GPS / NavSat plugin — simulates u-blox standard GPS (~0.5 m horizontal noise) -->
+        <gazebo reference="gps_link">
+            <sensor name="navsat_sensor" type="navsat">
+                <always_on>true</always_on>
+                <update_rate>10</update_rate>
+                <topic>gps/fix</topic>
+                <gz_frame_id>gps_link</gz_frame_id>
+                <navsat>
+                    <position_sensing>
+                        <horizontal>
+                            <noise type="gaussian">
+                                <mean>0.0</mean>
+                                <stddev>0.5</stddev>
+                            </noise>
+                        </horizontal>
+                        <vertical>
+                            <noise type="gaussian">
+                                <mean>0.0</mean>
+                                <stddev>0.8</stddev>
+                            </noise>
+                        </vertical>
+                    </position_sensing>
+                    <velocity_sensing>
+                        <horizontal>
+                            <noise type="gaussian">
+                                <mean>0.0</mean>
+                                <stddev>0.1</stddev>
+                            </noise>
+                        </horizontal>
+                        <vertical>
+                            <noise type="gaussian">
+                                <mean>0.0</mean>
+                                <stddev>0.1</stddev>
+                            </noise>
+                        </vertical>
+                    </velocity_sensing>
+                </navsat>
+            </sensor>
+        </gazebo>
+
         <!-- Camera Plugin-->
         <gazebo reference="camera_link">
             <sensor name="rgb_camera" type="camera">

--- a/unitree_go2_description/urdf/unitree_go2_robot.xacro
+++ b/unitree_go2_description/urdf/unitree_go2_robot.xacro
@@ -76,6 +76,36 @@
         <origin rpy="0 0 0" xyz="0 0 0" />
     </joint>
 
+    <!-- GPS link — mounted on top center of trunk -->
+    <joint name="gps_joint" type="fixed">
+        <parent link="trunk" />
+        <child link="gps_link" />
+        <origin rpy="0 0 0" xyz="0.0 0.0 0.065" />
+    </joint>
+
+    <link name="gps_link">
+        <inertial>
+            <mass value="0.001" />
+            <origin rpy="0 0 0" xyz="0 0 0" />
+            <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001" />
+        </inertial>
+        <visual>
+            <origin rpy="0 0 0" xyz="0 0 0" />
+            <geometry>
+                <box size="0.05 0.05 0.02" />
+            </geometry>
+            <material name="white">
+                <color rgba="1 1 1 1" />
+            </material>
+        </visual>
+        <collision>
+            <origin rpy="0 0 0" xyz="0 0 0" />
+            <geometry>
+                <box size="0.05 0.05 0.02" />
+            </geometry>
+        </collision>
+    </link>
+
     <link name="imu_link">
         <inertial>
             <mass value="0.001" />

--- a/unitree_go2_description/worlds/default.sdf
+++ b/unitree_go2_description/worlds/default.sdf
@@ -1,6 +1,16 @@
 <?xml version="1.0" ?>
 <sdf version="1.8">
   <world name="default">
+    <!-- Geographic origin for GPS simulation — change to match your actual test site -->
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>30.0444</latitude_deg>
+      <longitude_deg>31.2357</longitude_deg>
+      <elevation>74.0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+
     <physics name="1ms" type="bullet-featherstone">
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1.0</real_time_factor>
@@ -23,6 +33,10 @@
     <plugin
       filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="gz-sim-navsat-system"
+      name="gz::sim::systems::NavSat">
     </plugin>
     
     <!-- Lights -->

--- a/unitree_go2_sim/launch/unitree_go2_launch.py
+++ b/unitree_go2_sim/launch/unitree_go2_launch.py
@@ -245,6 +245,7 @@ def generate_launch_description():
             '/unitree_lidar/points@sensor_msgs/msg/PointCloud2@gz.msgs.PointCloudPacked',
             # '/velodyne_points@sensor_msgs/msg/LaserScan@gz.msgs.LaserScan',
             '/odom@nav_msgs/msg/Odometry@gz.msgs.Odometry',
+            '/gps/fix@sensor_msgs/msg/NavSatFix[gz.msgs.NavSat',
             '/rgb_image@sensor_msgs/msg/Image@gz.msgs.Image',
             # D455 RGBD camera bridges
             '/d455/image@sensor_msgs/msg/Image[gz.msgs.Image',


### PR DESCRIPTION
## Summary

- Adds a simulated GPS sensor to the Unitree Go2 using the Gazebo Harmonic `NavSat` plugin, modelling standard u-blox-level accuracy (~0.5 m horizontal).
- Mounts a `gps_link` on top of the robot trunk and wires the full pipeline from Gazebo sensor → ROS 2 bridge → `/gps/fix` topic.
- Sets a configurable geographic origin in the world SDF so the sensor outputs real lat/lon coordinates rather than zeros.

## Changes

| File | Change |
|------|--------|
| `unitree_go2_description/urdf/unitree_go2_robot.xacro` | Added `gps_link` and `gps_joint` fixed to trunk top |
| `unitree_go2_description/urdf/unitree_go2_gazebo.xacro` | Added NavSat sensor plugin with Gaussian position noise |
| `unitree_go2_description/worlds/default.sdf` | Added `gz-sim-navsat-system` world plugin and `<spherical_coordinates>` origin |
| `unitree_go2_sim/launch/unitree_go2_launch.py` | Added `/gps/fix` bridge (`gz.msgs.NavSat` → `sensor_msgs/msg/NavSatFix`) |
| `README.md` | Marked GPS as implemented; added configuration and usage section |

## Notes

- The `position_covariance` field in the bridged message will be all-zeros (`COVARIANCE_TYPE_UNKNOWN`) — this is a known limitation of the `gz-ros2-bridge`; the `gz.msgs.NavSat` format does not carry covariance. Set covariance overrides in your `robot_localization` EKF config or add a relay node.
- The geographic origin (lat/lon/altitude) in `default.sdf` is a placeholder — update `<spherical_coordinates>` to match your actual test site before running navigation experiments.

## Tested

- `/gps/fix` publishes `sensor_msgs/msg/NavSatFix` at 10 Hz with correct lat/lon output and expected Gaussian noise on position.
