### PR TITLE
Fix IMU inputs to EKF and use already existing EKF config 

### DIFF
--- a/champ_base/config/ekf/base_to_footprint.yaml
+++ b/champ_base/config/ekf/base_to_footprint.yaml
@@ -5,7 +5,6 @@ base_to_footprint_ekf:
     transform_timeout: 0.01
     transform_time_offset: 0.045
     two_d_mode: false
-    # diagnostics_agg: true
 
     #x     , y     , z,
     #roll  , pitch , yaw,
@@ -15,21 +14,19 @@ base_to_footprint_ekf:
 
     pose0: base_to_footprint_pose
     pose0_config: [true,  true,  true,
-                  true,  true,  true,
-                  false, false, false,
-                  false, false, false,
-                  false, false, false]
+                   true,  true,  true,
+                   false, false, false,
+                   false, false, false,
+                   false, false, false]
 
     imu0: imu/data
-    # imu0_config: [false, false, false,
-    #               false, false, false,
-    #               true, true, true,
-    #               false, false, false,
-    #               false, false, false]
+    imu0_remove_gravitational_acceleration: true
     imu0_config: [false, false, false,
-                  true, true, true,    # Use orientation (roll, pitch, yaw)
+                  true,  true,  false,
                   false, false, false,
-                  true, true, true,    # Use angular velocity (vroll, vpitch, vyaw)
-                  true, true, true]    # Use linear acceleration (ax, ay, az)
+                  true,  true,  false,
+                  false, false, true]
+
     odom_frame: base_footprint
+    base_link_frame: base_link
     world_frame: base_footprint

--- a/champ_base/config/ekf/footprint_to_odom.yaml
+++ b/champ_base/config/ekf/footprint_to_odom.yaml
@@ -3,9 +3,8 @@ footprint_to_odom_ekf:
     frequency: 50.0
     publish_tf: true
     transform_timeout: 0.01
-    # transform_time_offset: 0.05
+    transform_time_offset: 0.050
     two_d_mode: true
-    # diagnostics_agg: true
 
     #x     , y     , z,
     #roll  , pitch , yaw,
@@ -15,16 +14,16 @@ footprint_to_odom_ekf:
 
     odom0: odom/raw
     odom0_config: [false, false, false,
-                  false, false, false,
-                    true,  true, false,
-                  false, false, true,
-                  false, false, false]
+                   false, false, false,
+                   true,  true,  false,
+                   false, false, true,
+                   false, false, false]
 
     imu0: imu/data
     imu0_config: [false, false, false,
                   false, false, true,
                   false, false, false,
-                  false, false,  true,
+                  false, false, true,
                   false, false, false]
 
     odom_frame: odom

--- a/unitree_go2_sim/launch/unitree_go2_launch.py
+++ b/unitree_go2_sim/launch/unitree_go2_launch.py
@@ -19,7 +19,6 @@ from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitut
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration("use_sim_time")
-    base_frame = "base_link"
 
     unitree_go2_sim = launch_ros.substitutions.FindPackageShare(
         package="unitree_go2_sim").find("unitree_go2_sim")
@@ -130,7 +129,6 @@ def generate_launch_description():
         name="base_to_footprint_ekf",
         output="screen",
         parameters=[
-            {"base_link_frame": base_frame},
             {"use_sim_time": use_sim_time},
             os.path.join(
                 get_package_share_directory("champ_base"),

--- a/unitree_go2_sim/launch/unitree_go2_launch.py
+++ b/unitree_go2_sim/launch/unitree_go2_launch.py
@@ -147,16 +147,12 @@ def generate_launch_description():
         output="screen",
         parameters=[
             {"use_sim_time": use_sim_time},
-            {"base_link_frame": "base_footprint"},
-            {"odom_frame": "odom"},
-            {"world_frame": "odom"},
-            {"publish_tf": True},
-            {"frequency": 50.0},
-            {"two_d_mode": True},
-            {"odom0": "odom/raw"},
-            {"odom0_config": [False, False, False, False, False, False, True, True, False, False, False, True, False, False, False]},
-            {"imu0": "imu/data"},
-            {"imu0_config": [False, False, False, False, False, True, False, False, False, False, False, True, False, False, False]},
+            os.path.join(
+                get_package_share_directory("champ_base"),
+                "config",
+                "ekf",
+                "footprint_to_odom.yaml",
+            ),
         ],
         remappings=[("odometry/filtered", "odom")],
     )


### PR DESCRIPTION
### IMU fuse fix

According to REP-120 `base_to_footprint_ekf` was fusing the wrong IMU fields. It took full orientation, angular velocity, and linear acceleration. `imu0_remove_gravitational_acceleration` was not set, so gravity was fused as real acceleration, it could be seen in RViz with fixed frame set to map, odom or base_footprint as the robot jumpng. So probably fixed [issue 5](https://github.com/khaledgabr77/unitree_go2_ros2/issues/5). Now fused only roll/pitch, roll rate/pitch rate, z accel, gravity removed in `base_to_footprint_ekf`. `base_link_frame` moved into the YAML.

Before: 

https://github.com/user-attachments/assets/dcb8b221-80fc-417a-9728-d07d0c34d4cb

After:

https://github.com/user-attachments/assets/ad9a8038-e26f-47a5-8e8f-5f6f1c5bb648

### Use existent config

`footprint_to_odom.yaml` was unused. Every param was passed inline in unitree_go2_launch.py, so YAML edits did nothing. Node now loads the file; inline duplicates removed; transform_time_offset uncommented (0.050), I had flickering of point cloud messages without it in RViz.